### PR TITLE
fix: JSON.parse시 에러에 대한 처리

### DIFF
--- a/lambda/participants/put.ts
+++ b/lambda/participants/put.ts
@@ -211,8 +211,15 @@ export const handler = async (request: APIGatewayProxyEvent): Promise<APIGateway
   if (!request.body) {
     return BadRequestResult(request);
   }
+  let jsonBody = null;
+  try {
+    jsonBody = JSON.parse(request.body);
+  } catch (error) {
+    console.log('JSON parsing error:', error);
+    return BadRequestResult(request);
+  }
 
-  const payload = JSON.parse(request.body) as Participant;
+  const payload = jsonBody as Participant;
   if (email !== payload.Email) {
     return BadRequestResult(request);
   }


### PR DESCRIPTION
### 변경의 이유(Motivation)

request.body 를 JSON.parse할시 형식에 맞지 않게 들어오는 경우 오류가 발생하여 해결하려 한다.

### 변경의 종류(Type of Change)

- [x]  버그 수정(Bug fix)

### 변경 내용(Change List)

- JSON.parse시 try catch 로 에러 처리하도록 수정

### 관련 이슈(Related issue)

- 이슈 없습니다.

### 기대 효과(Intended Effects)

- JSON.parse할시 형식에 맞지 않게 들어오는 경우 오류를 정상적으로 처리합니다.

### 코드 품질(Code Quality)

- [x]  변경 사항을 자체적으로 리뷰했습니다 (I have performed a self-review of my own code)
- [x]  변경 사항을 로컬에서 테스트 했습니다 (I have tested on my local environment)

### 테스트(How Has This Been Tested?)

1. json으로 요청하는  row Data의 값을 null로 보내어 400에러가 나는지 확인한다.

### 리뷰어 체크리스트(Checklist for reviewers)

- [ ]  이 PR의 변경 사항을 로컬에서 테스트했습니다 (I have tested on my local environment)
- [ ]  변경 사항이 코딩 스타일 가이드를 준수하고 있습니다 (This PR follows the style guidelines)
- [ ]  [OWASP Top 10](https://owasp.org/www-project-top-ten/)을 고려해 보안 사항을 리뷰했습니다 (I have reviewed this PR against OWASP Top 10)
- [ ]  전체 단위 테스트를 성공적으로 실행했습니다 (I have confirmed that all unit tests are passed)